### PR TITLE
feat: improve homepage and integrate Gemini content generation

### DIFF
--- a/app1.html
+++ b/app1.html
@@ -145,6 +145,7 @@
     </div>
   </footer>
 
+  <script src="assets/app.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>
 </body>
 </html>

--- a/app10.html
+++ b/app10.html
@@ -76,6 +76,7 @@
       <small>© 2025 Педагог‑організатор. Всі права захищено.</small>
     </div>
   </footer>
+  <script src="assets/app.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>
 </body>
 </html>

--- a/app2.html
+++ b/app2.html
@@ -235,6 +235,7 @@
       <small>© 2025 Педагог‑організатор. Всі права захищено.</small>
     </div>
   </footer>
+  <script src="assets/app.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>
 </body>
 </html>

--- a/app3.html
+++ b/app3.html
@@ -142,6 +142,7 @@
       <small>© 2025 Педагог‑організатор. Всі права захищено.</small>
     </div>
   </footer>
+  <script src="assets/app.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>
 </body>
 </html>

--- a/app4.html
+++ b/app4.html
@@ -135,6 +135,7 @@
       <small>© 2025 Педагог‑організатор. Всі права захищено.</small>
     </div>
   </footer>
+  <script src="assets/app.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>
 </body>
 </html>

--- a/app5.html
+++ b/app5.html
@@ -113,6 +113,7 @@
       <small>© 2025 Педагог‑організатор. Всі права захищено.</small>
     </div>
   </footer>
+  <script src="assets/app.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>
 </body>
 </html>

--- a/app6.html
+++ b/app6.html
@@ -108,6 +108,7 @@
       <small>© 2025 Педагог‑організатор. Всі права захищено.</small>
     </div>
   </footer>
+  <script src="assets/app.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>
 </body>
 </html>

--- a/app7.html
+++ b/app7.html
@@ -121,6 +121,7 @@
       <small>© 2025 Педагог‑організатор. Всі права захищено.</small>
     </div>
   </footer>
+  <script src="assets/app.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>
 </body>
 </html>

--- a/app8.html
+++ b/app8.html
@@ -137,6 +137,7 @@
       <small>© 2025 Педагог‑організатор. Всі права захищено.</small>
     </div>
   </footer>
+  <script src="assets/app.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>
   <script>
     // Handle contact form submission

--- a/app9.html
+++ b/app9.html
@@ -88,6 +88,7 @@
       <small>© 2025 Педагог‑організатор. Всі права захищено.</small>
     </div>
   </footer>
+  <script src="assets/app.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>
 </body>
 </html>

--- a/assets/app.js
+++ b/assets/app.js
@@ -86,16 +86,16 @@
         alert('Будь ласка, вкажіть apiKey у параметрі URL: ?apiKey=YOUR_KEY');
         return;
       }
-      const sectionContext = section.innerText.trim();
-      const clone = document.body.cloneNode(true);
-      const ov = clone.querySelector('#geminiOverlay');
+      const sectionHtml = section.outerHTML;
+      const docClone = document.documentElement.cloneNode(true);
+      const ov = docClone.querySelector('#geminiOverlay');
       if (ov) ov.remove();
-      const pageContext = clone.innerText.trim();
+      const pageHtml = docClone.outerHTML;
       const requestBody = {
         system_instruction: {
-          parts: [{ text: 'You extend the given section. Only return JSON with field "html" containing extra HTML.' }]
+          parts: [{ text: 'You are a pedagogue-organizer assistant. Extend the given section with Bootstrap-friendly, responsive HTML. Use relative units so content blends with the existing layout. Only return JSON with field "html" containing the snippet.' }]
         },
-        contents: [{ parts: [{ text: `User request: ${prompt}\n\nPage context:\n${pageContext}\n\nSection context:\n${sectionContext}` }] }],
+        contents: [{ parts: [{ text: `User request: ${prompt}\n\nPage HTML:\n${pageHtml}\n\nSection HTML:\n${sectionHtml}` }] }],
         generationConfig: {
           responseMimeType: 'application/json',
           responseSchema: {

--- a/assets/app.js
+++ b/assets/app.js
@@ -1,0 +1,108 @@
+// Shared Gemini integration and content persistence
+(function(){
+  // Load bootstrap icons
+  var icon = document.createElement('link');
+  icon.rel = 'stylesheet';
+  icon.href = 'https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css';
+  document.head.appendChild(icon);
+
+  document.addEventListener('DOMContentLoaded', function(){
+    const params = new URLSearchParams(location.search);
+    const keyParam = params.get('apiKey');
+    const modelParam = params.get('model');
+    if (keyParam) localStorage.setItem('geminiApiKey', keyParam);
+    if (modelParam) localStorage.setItem('geminiModel', modelParam);
+    const apiKey = localStorage.getItem('geminiApiKey') || '';
+    const model = localStorage.getItem('geminiModel') || 'gemini-pro';
+
+    const storageKey = 'generated:' + location.pathname;
+    const saved = JSON.parse(localStorage.getItem(storageKey) || '{}');
+
+    // Add modal
+    const modalHtml = `
+<div class="modal fade" id="geminiModal" tabindex="-1">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Згенерувати контент</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Закрити"></button>
+      </div>
+      <div class="modal-body">
+        <textarea id="geminiPrompt" class="form-control" rows="4" placeholder="Опишіть, який контент потрібен"></textarea>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Закрити</button>
+        <button type="button" class="btn btn-primary" id="geminiGenerate">Згенерувати</button>
+      </div>
+    </div>
+  </div>
+</div>`;
+    document.body.insertAdjacentHTML('beforeend', modalHtml);
+    const modalEl = document.getElementById('geminiModal');
+    const bsModal = new bootstrap.Modal(modalEl);
+    let targetSection = null;
+
+    // Add buttons to sections
+    const sections = document.querySelectorAll('section');
+    sections.forEach((section, idx) => {
+      section.dataset.sectionId = 's'+idx;
+      const h = section.querySelector('h1, h2, h3, h4, h5, h6');
+      if (!h) return;
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'btn btn-sm btn-outline-secondary ms-2 gemini-btn';
+      btn.innerHTML = '<i class="bi bi-stars"></i>';
+      h.appendChild(btn);
+      btn.addEventListener('click', () => {
+        targetSection = section;
+        document.getElementById('geminiPrompt').value = '';
+        bsModal.show();
+      });
+      // Restore saved content
+      const html = saved[section.dataset.sectionId];
+      if (html) section.insertAdjacentHTML('beforeend', html);
+    });
+
+    async function generateContent(section, prompt){
+      if (!apiKey) {
+        alert('Будь ласка, вкажіть apiKey у параметрі URL: ?apiKey=YOUR_KEY');
+        return;
+      }
+      const context = section.innerText.trim();
+      const fullPrompt = `${prompt}\n\nКонтекст сторінки: ${document.title}. Поточний вміст секції:\n${context}\n\nПоверни HTML, який можна додати до сторінки.`;
+      try {
+        const resp = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${apiKey}`, {
+          method: 'POST',
+          headers: {'Content-Type': 'application/json'},
+          body: JSON.stringify({contents: [{parts: [{text: fullPrompt}]}]})
+        });
+        const data = await resp.json();
+        const text = data.candidates?.[0]?.content?.parts?.map(p=>p.text).join('') || '';
+        if (text) {
+          section.insertAdjacentHTML('beforeend', `<div class="generated mt-2">${text}</div>`);
+          save();
+        }
+      } catch(err){
+        console.error(err);
+        alert('Не вдалося отримати відповідь від Gemini');
+      }
+    }
+
+    function save(){
+      const obj = {};
+      sections.forEach(sec => {
+        const gen = Array.from(sec.querySelectorAll('.generated')).map(d=>d.outerHTML).join('');
+        if (gen) obj[sec.dataset.sectionId] = gen;
+      });
+      localStorage.setItem(storageKey, JSON.stringify(obj));
+    }
+
+    document.getElementById('geminiGenerate').addEventListener('click', async () => {
+      const prompt = document.getElementById('geminiPrompt').value.trim();
+      bsModal.hide();
+      if (prompt && targetSection) {
+        await generateContent(targetSection, prompt);
+      }
+    });
+  });
+})();

--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
     .hero {
       padding-top: 4rem;
       padding-bottom: 4rem;
+      background: linear-gradient(135deg, #e3f2fd, #ffffff);
     }
     .hero img {
       max-width: 100%;
@@ -53,7 +54,7 @@
   <!-- Hero section -->
   <section class="hero mt-5">
     <div class="container">
-      <div class="row align-items-center">
+      <div class="row align-items-center text-center text-lg-start">
         <div class="col-lg-6 mb-4 mb-lg-0">
           <h1 class="display-4 fw-bold">Вітаємо на ресурсі педагога‑організатора</h1>
           <p class="lead">Цей веб‑застосунок містить корисні міні‑програми та матеріали для роботи педагога‑організатора на 2025–2026 навчальний рік. Оберіть потрібний розділ, щоб розпочати.</p>
@@ -183,6 +184,7 @@
   </footer>
 
   <!-- Bootstrap JS -->
+  <script src="assets/app.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js" integrity="sha384-ENjdO4Dr2bkBIFxQpeo64P0x7bS2bQ+Ws4PrUFCeA9noELlN7p1F7HQZ3nxkJ0St" crossorigin="anonymous"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- polish landing page with gradient hero and responsive alignment
- add shared Gemini API client, section-level content generation modal, and localStorage persistence
- load Gemini script on all mini-app pages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a209baebbc8332b0b7c496e2fbfb9b